### PR TITLE
Address #2, fix modulefile env usage

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,10 +29,10 @@ else
   echo "continuing from previous builds, using source at " ${SRC_DIR}/${SOURCE_FILE}
 fi
 tar xzf  ${SRC_DIR}/${SOURCE_FILE} -C ${WORKSPACE} --skip-old-files
-mkdir -p ${WORKSPACE}/${VERSION}/build-${BUILD_NUMBER}
-cd ${WORKSPACE}/${VERSION}/build-${BUILD_NUMBER}
+mkdir -p ${WORKSPACE}/${NAME}${VERSION}/build-${BUILD_NUMBER}
+cd ${WORKSPACE}/${NAME}${VERSION}/build-${BUILD_NUMBER}
 # This CMake doesn't allow in-source build
-cmake ${WORKSPACE}/${VERSION}  -G"Unix Makefiles" \
+cmake ${WORKSPACE}/${NAME}${VERSION}    -G"Unix Makefiles" \
    -DCMAKE_INSTALL_PREFIX=${SOFT_DIR}\
    -DGEANT4_INSTALL_DATA_TIMEOUT=1500                \
    -DCMAKE_CXX_FLAGS="-fPIC"                         \

--- a/check-build.sh
+++ b/check-build.sh
@@ -4,7 +4,7 @@ module add ci
 module add cmake
 module add clhep/${CLHEP_VERSION}
 
-cd ${WORKSPACE}/${VERSION}/build-${BUILD_NUMBER}
+cd ${WORKSPACE}/${NAME}${VERSION}/build-${BUILD_NUMBER}
 make test
 
 echo $?
@@ -39,26 +39,26 @@ module-whatis   "
 "
 setenv       GEANT4_VERSION       $VERSION
 setenv       GEANT4_DIR           /data/ci-build/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION
-setenv  GEANT4BASE                $env(GEANT4_DIR)
-setenv  G4INCLUDE               $env(GEANT4BASE)/include/geant4
-setenv  G4INSTALL           $env(GEANT4BASE)/src/geant4
-setenv  G4ABLADATA                  $env(GEANT4BASE)/data/G4ABLA3.0
-setenv  G4LEDATA          $env(GEANT4BASE)/data/G4EMLOW6.9
-setenv  G4LEVELGAMMADATA        $env(GEANT4BASE)/data/PhotonEvaporation2.0
-setenv  G4NEUTRONHPDATA         $env(GEANT4BASE)/data/G4NDL3.13
-setenv  G4RADIOACTIVEDATA         $env(GEANT4BASE)/data/RadioactiveDecay3.2
-setenv  G4REALSURFACEDATA         $env(GEANT4BASE)/data/RealSurface1.0
+setenv  GEANT4BASE                $::env(GEANT4_DIR)
+setenv  G4INCLUDE               $::env(GEANT4BASE)/include/geant4
+setenv  G4INSTALL           $::env(GEANT4BASE)/src/geant4
+setenv  G4ABLADATA                  $::env(GEANT4BASE)/data/G4ABLA3.0
+setenv  G4LEDATA          $::env(GEANT4BASE)/data/G4EMLOW6.9
+setenv  G4LEVELGAMMADATA        $::env(GEANT4BASE)/data/PhotonEvaporation2.0
+setenv  G4NEUTRONHPDATA         $::env(GEANT4BASE)/data/G4NDL3.13
+setenv  G4RADIOACTIVEDATA         $::env(GEANT4BASE)/data/RadioactiveDecay3.2
+setenv  G4REALSURFACEDATA         $::env(GEANT4BASE)/data/RealSurface1.0
 setenv  G4LIB_BUILD_SHARED        1
 setenv  G4LIB_BUILD_STATIC        1
-setenv  G4LIB           $env(GEANT4BASE)/lib/geant4
+setenv  G4LIB           $::env(GEANT4BASE)/lib/geant4
 setenv  G4LIB_USE_GRANULAR        1
 setenv  G4SYSTEM          Linux-g++
 setenv  G4UI_USE_TCSH         1
 setenv  G4VIS_BUILD_VRML_DRIVER       1
 setenv  G4VIS_USE_VRML                1
-setenv  G4WORKDIR                     $env(HOME)/geant4
-prepend-path  LD_LIBRARY_PATH     $env(GEANT4BASE)/lib/geant4/Linux-g++
-prepend-path  PATH        $env(HOME)/geant4/bin/Linux-g++
+setenv  G4WORKDIR                     $::env(HOME)/geant4
+prepend-path  LD_LIBRARY_PATH     $::env(GEANT4BASE)/lib/geant4/Linux-g++
+prepend-path  PATH        $::env(HOME)/geant4/bin/Linux-g++
 
 prepend-path CFLAGS            "-I${G4INCLUDE}"
 prepend-path LDFLAGS           "-L${G4LIB}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -5,10 +5,10 @@ module add deploy
 module add cmake
 module add clhep/${CLHEP_VERSION}
 
-cd ${WORKSPACE}/${VERSION}/build-${BUILD_NUMBER}
+cd ${WORKSPACE}/${NAME}${VERSION}/build-${BUILD_NUMBER}
 echo "All tests have passed, will now build into ${SOFT_DIR}"
 rm -rf *
-cmake ${WORKSPACE}/${VERSION}/ -G"Unix Makefiles" \
+cmake ${WORKSPACE}/${NAME}${VERSION}/ -G"Unix Makefiles" \
    -DCMAKE_INSTALL_PREFIX=${SOFT_DIR}\
    -DGEANT4_INSTALL_DATA_TIMEOUT=1500                \
    -DCMAKE_CXX_FLAGS="-fPIC"                         \
@@ -53,27 +53,27 @@ module-whatis   "
 $NAME $VERSION : See https://github.com/SouthAfricaDigitalScience/geant4-deploy
 "
 setenv       GEANT4_VERSION       $VERSION
-setenv       GEANT4_DIR           /data/ci-build/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION
-setenv  GEANT4BASE                $env(GEANT4_DIR)
-setenv  G4INCLUDE               $env(GEANT4BASE)/include/geant4
-setenv  G4INSTALL           $env(GEANT4BASE)/src/geant4
-setenv  G4ABLADATA                  $env(GEANT4BASE)/data/G4ABLA3.0
-setenv  G4LEDATA          $env(GEANT4BASE)/data/G4EMLOW6.9
-setenv  G4LEVELGAMMADATA        $env(GEANT4BASE)/data/PhotonEvaporation2.0
-setenv  G4NEUTRONHPDATA         $env(GEANT4BASE)/data/G4NDL3.13
-setenv  G4RADIOACTIVEDATA         $env(GEANT4BASE)/data/RadioactiveDecay3.2
-setenv  G4REALSURFACEDATA         $env(GEANT4BASE)/data/RealSurface1.0
+setenv       GEANT4_DIR           $::env(CVMFS_DIR)/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION
+setenv  GEANT4BASE                $::env(GEANT4_DIR)
+setenv  G4INCLUDE               $::env(GEANT4BASE)/include/geant4
+setenv  G4INSTALL           $::env(GEANT4BASE)/src/geant4
+setenv  G4ABLADATA                  $::env(GEANT4BASE)/data/G4ABLA3.0
+setenv  G4LEDATA          $::env(GEANT4BASE)/data/G4EMLOW6.9
+setenv  G4LEVELGAMMADATA        $::env(GEANT4BASE)/data/PhotonEvaporation2.0
+setenv  G4NEUTRONHPDATA         $::env(GEANT4BASE)/data/G4NDL3.13
+setenv  G4RADIOACTIVEDATA         $::env(GEANT4BASE)/data/RadioactiveDecay3.2
+setenv  G4REALSURFACEDATA         $::env(GEANT4BASE)/data/RealSurface1.0
 setenv  G4LIB_BUILD_SHARED        1
 setenv  G4LIB_BUILD_STATIC        1
-setenv  G4LIB           $env(GEANT4BASE)/lib/geant4
+setenv  G4LIB           $::env(GEANT4BASE)/lib/geant4
 setenv  G4LIB_USE_GRANULAR        1
 setenv  G4SYSTEM          Linux-g++
 setenv  G4UI_USE_TCSH         1
 setenv  G4VIS_BUILD_VRML_DRIVER       1
 setenv  G4VIS_USE_VRML                1
-setenv  G4WORKDIR                     $env(HOME)/geant4
-prepend-path  LD_LIBRARY_PATH     $env(GEANT4BASE)/lib/geant4/Linux-g++
-prepend-path  PATH        $env(HOME)/geant4/bin/Linux-g++
+setenv  G4WORKDIR                     $::env(HOME)/geant4
+prepend-path  LD_LIBRARY_PATH     $::env(GEANT4BASE)/lib/geant4/Linux-g++
+prepend-path  PATH        $::env(HOME)/geant4/bin/Linux-g++
 
 prepend-path CFLAGS            "-I${G4INCLUDE}"
 prepend-path LDFLAGS           "-L${G4LIB}"
@@ -85,24 +85,4 @@ mkdir -p ${HEP_MODULES}/${NAME}
 cp -v modules/$VERSION ${HEP_MODULES}/${NAME}
 module avail ${NAME}
 module add  ${NAME}/${VERSION}
-
-----------------
-
-
-
-
-
-setenv GEANT4_VERSION       $VERSION
-setenv GEANT4_DIR           $::env(CVMFS_DIR)/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION
-prepend-path LD_LIBRARY_PATH   $::env(GEANT4_DIR)/lib
-prepend-path CFLAGS            "-I$::env(GEANT4_DIR)/include"
-prepend-path LDFLAGS           "-L::env(GEANT4_DIR)/lib"
-prepend-path PATH              $::env(GEANT4_DIR)/bin
-MODULE_FILE
-) > modules/$VERSION
-
-cp -v modules/$VERSION ${HEP_MODULES}/${NAME}
-
-
-module add ${NAME}/${VERSION}
 which geant4-config


### PR DESCRIPTION
The usage of environment variables in tcl needs `$::env` instead
of `$env` - changed this in the check-build and deploy scripts.

Using the `${NAME}${VERSION}` schema of the untar dirs.