### PR TITLE
Decouple data from install directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project depends on
   * cmake
   * gcc
   * clhep
-  
+
 
 # Versions
 
@@ -25,7 +25,25 @@ We build the following versions :
 The builds are configured out-of-source with cmake :
 
 ```
-cmake -G"Unix Makefiles" -DCMAKE_INSTALL_PREFIX=${SOFT_DIR}
-```
+cmake ${WORKSPACE}/${NAME}.${VERSION}    -G"Unix Makefiles" \
+  -DGEANT4_INSTALL_DATADIR=${SOFT_DIR}/data \
+   -DCMAKE_INSTALL_PREFIX=${SOFT_DIR}-clhep-${CLHEP_VERSION}-gcc-${GCC_VERSION} \
+   -DGEANT4_INSTALL_DATA_TIMEOUT=1500                \
+   -DCMAKE_CXX_FLAGS="-fPIC"                         \
+   -DCMAKE_INSTALL_LIBDIR="lib"     \
+   -DCMAKE_BUILD_TYPE=RelWithDebInfo    \
+   -DGEANT4_BUILD_TLS_MODEL:STRING="global-dynamic"  \
+   -DGEANT4_ENABLE_TESTING=OFF    \
+   -DBUILD_SHARED_LIBS=ON    \
+   -DGEANT4_INSTALL_EXAMPLES=ON  \
+   -DCLHEP_ROOT_DIR:PATH="${CLHEP_ROOT}"  \
+   -DGEANT4_BUILD_MULTITHREADED=OFF  \
+   -DCMAKE_STATIC_LIBRARY_CXX_FLAGS="-fPIC"  \
+   -DCMAKE_STATIC_LIBRARY_C_FLAGS="-fPIC"  \
+   -DGEANT4_USE_G3TOG4=ON   \
+   -DGEANT4_INSTALL_DATA=ON   \
+   -DGEANT4_USE_SYSTEM_EXPAT=OFF \
+   -DGEANT4_BUILD_TESTS=ON
+   ```
 
 # Citing

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ mkdir -p ${WORKSPACE}/${NAME}.${VERSION}/build-${BUILD_NUMBER}
 cd ${WORKSPACE}/${NAME}.${VERSION}/build-${BUILD_NUMBER}
 # This CMake doesn't allow in-source build
 cmake ${WORKSPACE}/${NAME}.${VERSION}    -G"Unix Makefiles" \
+  -DGEANT4_INSTALL_DATADIR=${SOFT_DIR}/data \
    -DCMAKE_INSTALL_PREFIX=${SOFT_DIR}-clhep-${CLHEP_VERSION}-gcc-${GCC_VERSION} \
    -DGEANT4_INSTALL_DATA_TIMEOUT=1500                \
    -DCMAKE_CXX_FLAGS="-fPIC"                         \

--- a/check-build.sh
+++ b/check-build.sh
@@ -23,7 +23,7 @@ proc ModulesHelp { } {
 }
 module-whatis   "
 [Category      ] physics
-[Nam           ] $NAME
+[Name           ] $NAME
 [Version       ] $VERSION
 [Description   ] Geant4 is a toolkit for the simulation of the passage of particles through matter. It used in particle, nuclear, accelerator, and medical physics, together with space science and right across science
 [Website       ] http://${NAME}.4.cern.ch
@@ -31,28 +31,29 @@ module-whatis   "
 [Dependencies  ] clhep ${CLHEP_VERSION}-gcc-${GCC_VERSION}
 "
 setenv       GEANT4_VERSION       $VERSION
-setenv       GEANT4_DIR           /data/ci-build/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION
-setenv  GEANT4BASE                $::env(GEANT4_DIR)
-setenv  G4INCLUDE               $::env(GEANT4BASE)/include/geant4
-setenv  G4INSTALL           $::env(GEANT4BASE)/src/geant4
-setenv  G4ABLADATA                  $::env(GEANT4BASE)/data/G4ABLA3.0
-setenv  G4LEDATA          $::env(GEANT4BASE)/data/G4EMLOW6.9
-setenv  G4LEVELGAMMADATA        $::env(GEANT4BASE)/data/PhotonEvaporation2.0
-setenv  G4NEUTRONHPDATA         $::env(GEANT4BASE)/data/G4NDL3.13
-setenv  G4RADIOACTIVEDATA         $::env(GEANT4BASE)/data/RadioactiveDecay3.2
-setenv  G4REALSURFACEDATA         $::env(GEANT4BASE)/data/RealSurface1.0
-setenv  G4LIB_BUILD_SHARED        1
+setenv       GEANT4_DIR           /data/ci-build/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION-clhep-${CLHEP_VERSION}-gcc-${GCC_VERSION}
+setenv        GEANT4_DATA  $::env(GEANT4BASE)/data/
+setenv  GEANT4BASE         /data/ci-build/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/
+setenv  G4INCLUDE                         $::env(GEANT4_DIR)/include/geant4
+setenv  G4INSTALL                          $::env(GEANT4_DIR)/src/geant4
+setenv  G4ABLADATA                      $::env(GEANT4_DATA)/G4ABLA3.0
+setenv  G4LEDATA                            $::env(GEANT4_DATA)/G4EMLOW6.9
+setenv  G4LEVELGAMMADATA      $::env(GEANT4_DATA)/PhotonEvaporation2.0
+setenv  G4NEUTRONHPDATA         $::env(GEANT4_DATA)/G4NDL3.13
+setenv  G4RADIOACTIVEDATA       $::env(GEANT4_DATA)/RadioactiveDecay3.2
+setenv  G4REALSURFACEDATA     $::env(GEANT4_DATA)/RealSurface1.0
+setenv  G4LIB_BUILD_SHARED      1
 setenv  G4LIB_BUILD_STATIC        1
-setenv  G4LIB           $::env(GEANT4BASE)/lib/geant4
+setenv  G4LIB           $::env(GEANT4_DIR)/lib/geant4
 setenv  G4LIB_USE_GRANULAR        1
 setenv  G4SYSTEM          Linux-g++
 setenv  G4UI_USE_TCSH         1
 setenv  G4VIS_BUILD_VRML_DRIVER       1
 setenv  G4VIS_USE_VRML                1
 setenv  G4WORKDIR                     $::env(HOME)/geant4
-prepend-path  LD_LIBRARY_PATH     $::env(GEANT4BASE)/lib/geant4/Linux-g++
+prepend-path  LD_LIBRARY_PATH     $::env(GEANT4_DIR)/lib/geant4/Linux-g++
 prepend-path  PATH        $::env(HOME)/geant4/bin/Linux-g++
-
+prepend-path  PATH         $::env(GEANT4_DIR)/bin
 prepend-path CFLAGS            "-I${G4INCLUDE}"
 prepend-path LDFLAGS           "-L${G4LIB}"
 MODULE_FILE

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,27 +54,27 @@ $NAME $VERSION : See https://github.com/SouthAfricaDigitalScience/geant4-deploy
 "
 setenv       GEANT4_VERSION       $VERSION
 setenv       GEANT4_DIR           $::env(CVMFS_DIR)/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/$VERSION-gcc-${GCC_VERSION}
-setenv  GEANT4BASE                $::env(GEANT4_DIR)
-setenv  G4INCLUDE               $::env(GEANT4BASE)/include/geant4
-setenv  G4INSTALL           $::env(GEANT4BASE)/src/geant4
-setenv  G4ABLADATA                  $::env(GEANT4BASE)/data/G4ABLA3.0
-setenv  G4LEDATA          $::env(GEANT4BASE)/data/G4EMLOW6.9
-setenv  G4LEVELGAMMADATA        $::env(GEANT4BASE)/data/PhotonEvaporation2.0
-setenv  G4NEUTRONHPDATA         $::env(GEANT4BASE)/data/G4NDL3.13
-setenv  G4RADIOACTIVEDATA         $::env(GEANT4BASE)/data/RadioactiveDecay3.2
-setenv  G4REALSURFACEDATA         $::env(GEANT4BASE)/data/RealSurface1.0
-setenv  G4LIB_BUILD_SHARED        1
+setenv  GEANT4BASE                $::env(CVMFS_DIR)/$::env(SITE)/$::env(OS)/$::env(ARCH)/$NAME/
+setenv  G4INCLUDE                         $::env(GEANT4_DIR)/include/geant4
+setenv  G4INSTALL                          $::env(GEANT4_DIR)/src/geant4
+setenv  G4ABLADATA                      $::env(GEANT4_DATA)/G4ABLA3.0
+setenv  G4LEDATA                            $::env(GEANT4_DATA)/G4EMLOW6.9
+setenv  G4LEVELGAMMADATA      $::env(GEANT4_DATA)/PhotonEvaporation2.0
+setenv  G4NEUTRONHPDATA         $::env(GEANT4_DATA)/G4NDL3.13
+setenv  G4RADIOACTIVEDATA       $::env(GEANT4_DATA)/RadioactiveDecay3.2
+setenv  G4REALSURFACEDATA     $::env(GEANT4_DATA)/RealSurface1.0
+setenv  G4LIB_BUILD_SHARED      1
 setenv  G4LIB_BUILD_STATIC        1
-setenv  G4LIB           $::env(GEANT4BASE)/lib/geant4
+setenv  G4LIB           $::env(GEANT4_DIR)/lib/geant4
 setenv  G4LIB_USE_GRANULAR        1
 setenv  G4SYSTEM          Linux-g++
 setenv  G4UI_USE_TCSH         1
 setenv  G4VIS_BUILD_VRML_DRIVER       1
 setenv  G4VIS_USE_VRML                1
 setenv  G4WORKDIR                     $::env(HOME)/geant4
-prepend-path  LD_LIBRARY_PATH     $::env(GEANT4BASE)/lib/geant4/Linux-g++
+prepend-path  LD_LIBRARY_PATH     $::env(GEANT4_DIR)/lib/geant4/Linux-g++
 prepend-path  PATH        $::env(HOME)/geant4/bin/Linux-g++
-
+prepend-path  PATH         $::env(GEANT4_DIR)/bin
 prepend-path CFLAGS            "-I${G4INCLUDE}"
 prepend-path LDFLAGS           "-L${G4LIB}"
 MODULE_FILE


### PR DESCRIPTION
This addresses #16
We set a new environment variable called `$G4BASE`
which tracks `$SOFT_DIR`. Data is installed to `$G4BASE/data`
where it can be cached and used by all versions of Geant4 instead
of unnecessarily downloading repeatedly the same file.

Other fixes :

  1. This commit also adds `$GEANT4_DIR/bin` to the `PATH` so that we can
find `geant4-config`
  1. The install path is corrected for CLHEP and GCC versions